### PR TITLE
fix(admin): 文件管理「打开」URL 双斜杠且无法打开 (#11)

### DIFF
--- a/app/admin/controller/FilesystemController.php
+++ b/app/admin/controller/FilesystemController.php
@@ -222,7 +222,7 @@ class FilesystemController extends AbsSourceController
         $path = $request->post('path');
 
         return amis_response([
-            'url' => $this->disk()->url($path),
+            'url' => Storage::temporaryUrlForBrowser($path, disk: $this->disk()),
         ]);
     }
 }

--- a/config/plugin/webman-tech/laravel-filesystem/filesystems.php
+++ b/config/plugin/webman-tech/laravel-filesystem/filesystems.php
@@ -14,6 +14,7 @@ return [
         'local' => [
             'driver' => 'local',
             'root' => storage_path('app'),
+            'url' => get_env('APP_URL') . '/storage',
             'throw' => false,
         ],
         'public' => [
@@ -36,6 +37,6 @@ return [
         ],
     ],
     'links' => [
-        public_path('storage') => storage_path('app/public'),
+        public_path('storage') => storage_path('app'),
     ],
 ];

--- a/environments/dev/env.php
+++ b/environments/dev/env.php
@@ -3,6 +3,7 @@
 // region app
 put_env('APP_DEBUG', true);
 put_env('APP_NAME', 'webman-basic');
+put_env('APP_URL', 'http://localhost:8787'); // 本地访问地址，供 storage 生成绝对 URL（文件管理「打开」用）
 // endregion
 
 // region server

--- a/support/facade/Storage.php
+++ b/support/facade/Storage.php
@@ -2,6 +2,73 @@
 
 namespace support\facade;
 
+use app\components\Tools;
+use Carbon\Carbon;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemAdapter;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use support\Request;
+
 class Storage extends \WebmanTech\LaravelFilesystem\Facades\Storage
 {
+    /**
+     * 给浏览器提供用的临时 url
+     * 在 ttl 有效期内，不会重复生成签名，防止浏览器缓存不起作用的问题
+     * 但会导致每次调用该方式时实际生成的 url 并非在当前时间往后 ttl 时间内可用
+     */
+    public static function temporaryUrlForBrowser(string $path, array $options = [], int $ttl = 3600, ?Filesystem $disk = null): string
+    {
+        $disk ??= static::instance()->disk();
+        if (!$disk instanceof FilesystemAdapter) {
+            throw new \InvalidArgumentException('Disk must be instance of FilesystemAdapter');
+        }
+        $adapter = $disk->getAdapter();
+        if ($adapter instanceof LocalFilesystemAdapter) {
+            // local 不需要签名
+            $url = $disk->url($path);
+            if (str_starts_with($url, '/')) {
+                // 非域名模式时，需要补充前缀
+                $request = request();
+                if (self::isRequestFromAppFront($request)) {
+                    return get_env('APP_FRONT_PROXY_PREFIX', '/api/server') . $url;
+                } else {
+                    $url = '/' . ltrim($request->pathPrefix() . $url, '/');
+                }
+            }
+            return $url;
+        }
+        if (!get_env('OSS_BUCKET_USE_PRIVATE')) {
+            // 未使用 private 的 bucket 直接返回 url
+            return $disk->url($path);
+        }
+        // 需要签名的，给签名的数据缓存一段时间
+        $expiration = Carbon::now()->addSeconds($ttl);
+        return cache()->remember(
+            'storage:temp_url:' . Tools::buildKey([__CLASS__, __FUNCTION__, func_get_args()]),
+            $ttl - 30,
+            fn() => $disk->temporaryUrl($path, $expiration, $options)
+        );
+    }
+
+    private static function isRequestFromAppFront(Request $request): bool
+    {
+        if ($request->header('x-proxy-from-node') === 'true') {
+            // 前端代理主动设置的 header
+            return true;
+        }
+        if ($request->header('user-agent') === 'node') {
+            // 前端刷新页面时，会使用 node 后端来请求，此时的标志
+            return true;
+        }
+        if ($referer = $request->header('referer')) {
+            if (
+                !str_contains($referer, '/api/') // 带有 / 后缀是为了更加精确
+                && !str_contains($referer, '/admin') // 不带 / 后缀是因为 admin 的后台 amis 访问是不以 / 结尾的
+            ) {
+                // 有 referer，但是 referer 中不是 /api 或 /admin 端口的
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## 问题
admin 文件管理模块点击「打开」文件时，产出的 URL 为 `/storage//images/...`（双斜杠），且因 amis 将其当作 hash 路由，文件实际打不开（404）。见 issue #11。

## 修复
- 新增 `support/facade/Storage::temporaryUrlForBrowser()`：local 磁盘返回 `url` 配置拼接的绝对地址（有 `url` 配置时 Laravel `concatPathToUrl` 会 `ltrim` 前导 `/`，消除双斜杠）；Cloud 磁盘返回签名临时 URL。
- `FilesystemController::url()` 改用 `Storage::temporaryUrlForBrowser()`。
- `local` 磁盘补充 `url` 配置；`links` 软链目标对齐为 `storage/app`（local 磁盘根目录），文件可被 web 直接访问。
- dev 环境补充 `APP_URL`，确保 storage 生成绝对 URL（amis `redirect` 才能真实打开文件）。

## 验证
本地启服务并用浏览器实测：点击「打开」后地址栏为 `http://localhost:8787/storage/images/...`（单斜杠、绝对地址），curl 返回 200 `image/jpeg`，文件真实打开。

Closes #11